### PR TITLE
say we've got error for better developer usability

### DIFF
--- a/shellpromise.js
+++ b/shellpromise.js
@@ -31,9 +31,7 @@ function shellpromise (processToRun, options) {
 			if (code === 0) {
 				resolve(output);
 			} else {
-				if (options.verbose) {
-					console.warn(processToRun + ' exited with exit code ' + code);
-				}
+				console.warn(processToRun + ' exited with a non-zero (error) exit code ' + code);
 				reject(new Error(output));
 			}
 		});


### PR DESCRIPTION
We had problems with `npm ls` (deep in `haikro`) earlier today because it didn't output any indication that it had errors/issues. Only a bad return code that we didn't know about, made worse by the fact that it was `--log-leve=silence`.

I realise that one reason for this design is for ease of integration & scriptability (string comparison with error output) but hey IMHO a bad error output is far better than a silent error output. :)